### PR TITLE
Add Docker Compose setup instructions for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,37 @@
 # docker_assignment
 Here's a README file that explains how to implement the Docker Compose manifest, configure sensitive and configurable variables, manage Docker volumes, and run the containers:
 
-Dockerized PostgreSQL Database
+# Dockerized PostgreSQL Database
 This repository contains files to set up a Docker Compose manifest for creating a PostgreSQL database container. It includes instructions for overriding default credentials, passing sensitive and configurable variables using an .env file, configuring Docker volumes for data persistence, and running the containers.
 
-Getting Started
+# Getting Started
 Follow these instructions to set up and run the PostgreSQL database container locally.
 
-Prerequisites
+# Prerequisites
 Make sure you have Docker and Docker Compose installed on your system. You can download and install Docker Desktop from here.
 
-Configuration
-Clone this repository to your local machine:
+# Configuration
 
+1. Clone this repository to your local machine:
 git clone <repository_url>
-Navigate to the repository directory:
 
+2.Navigate to the repository directory:
 cd <repository_directory>
-Create a .env file in the repository directory and specify the sensitive and configurable variables:
+
+3. Create a .env file in the repository directory and specify the sensitive and configurable variables:
 
 POSTGRES_USER=myuser
 POSTGRES_PASSWORD=mypassword
 POSTGRES_DB=mydatabase
 Replace myuser, mypassword, and mydatabase with your desired username, password, and database name, respectively.
 
-Running the Containers
+# Running the Containers
 Run the following command to start the PostgreSQL database container:
 
 docker-compose up -d
 This command will build the Docker image and start the container in detached mode.
 
-Verification
+# Verification
 To verify that the container is running and accessible, you can use a database management tool such as DBeaver to connect to the PostgreSQL database using the following credentials:
 
 Host: localhost
@@ -40,18 +41,13 @@ Password: <POSTGRES_PASSWORD>
 Database: <POSTGRES_DB>
 Make sure to replace <POSTGRES_USER>, <POSTGRES_PASSWORD>, and <POSTGRES_DB> with the values specified in your .env file.
 
-Stopping the Containers
+# Stopping the Containers
 To stop the PostgreSQL database container, run:
 
 docker-compose down
 This command will stop and remove the containers.
 
-Data Persistence
+# Data Persistence
 Data in the PostgreSQL database will be persisted across container restarts and re-creations thanks to Docker volumes. The data is stored in a Docker volume named postgres-data, which is created and managed by Docker Compose.
 
-Additional Information
-For more information about Docker and Docker Compose, refer to the official documentation:
-
-Docker Documentation
-Docker Compose Documentation
 Feel free to modify and enhance this README file as needed to fit your specific project requirements.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
 # docker_assignment
+Here's a README file that explains how to implement the Docker Compose manifest, configure sensitive and configurable variables, manage Docker volumes, and run the containers:
+
+Dockerized PostgreSQL Database
+This repository contains files to set up a Docker Compose manifest for creating a PostgreSQL database container. It includes instructions for overriding default credentials, passing sensitive and configurable variables using an .env file, configuring Docker volumes for data persistence, and running the containers.
+
+Getting Started
+Follow these instructions to set up and run the PostgreSQL database container locally.
+
+Prerequisites
+Make sure you have Docker and Docker Compose installed on your system. You can download and install Docker Desktop from here.
+
+Configuration
+Clone this repository to your local machine:
+
+git clone <repository_url>
+Navigate to the repository directory:
+
+cd <repository_directory>
+Create a .env file in the repository directory and specify the sensitive and configurable variables:
+
+POSTGRES_USER=myuser
+POSTGRES_PASSWORD=mypassword
+POSTGRES_DB=mydatabase
+Replace myuser, mypassword, and mydatabase with your desired username, password, and database name, respectively.
+
+Running the Containers
+Run the following command to start the PostgreSQL database container:
+
+docker-compose up -d
+This command will build the Docker image and start the container in detached mode.
+
+Verification
+To verify that the container is running and accessible, you can use a database management tool such as DBeaver to connect to the PostgreSQL database using the following credentials:
+
+Host: localhost
+Port: 5432
+Username: <POSTGRES_USER>
+Password: <POSTGRES_PASSWORD>
+Database: <POSTGRES_DB>
+Make sure to replace <POSTGRES_USER>, <POSTGRES_PASSWORD>, and <POSTGRES_DB> with the values specified in your .env file.
+
+Stopping the Containers
+To stop the PostgreSQL database container, run:
+
+docker-compose down
+This command will stop and remove the containers.
+
+Data Persistence
+Data in the PostgreSQL database will be persisted across container restarts and re-creations thanks to Docker volumes. The data is stored in a Docker volume named postgres-data, which is created and managed by Docker Compose.
+
+Additional Information
+For more information about Docker and Docker Compose, refer to the official documentation:
+
+Docker Documentation
+Docker Compose Documentation
+Feel free to modify and enhance this README file as needed to fit your specific project requirements.


### PR DESCRIPTION
**Description:**

This pull request adds comprehensive instructions for setting up a Docker Compose manifest to deploy a PostgreSQL database container. The provided README file guides users through configuring sensitive and configurable variables, managing Docker volumes for data persistence, and running the containers locally. By following these instructions, users can effortlessly deploy a PostgreSQL database instance with custom credentials and settings.

**Changes Made:**

Added detailed instructions for implementing the Docker Compose manifest.
Included guidance on configuring sensitive and configurable variables using an .env file.
Provided steps for managing Docker volumes to ensure data persistence.
Added instructions for running and verifying the PostgreSQL container locally.
Included information on stopping the containers gracefully.
Provided details on data persistence using Docker volumes.
Included references to official Docker and Docker Compose documentation for further assistance.

This contribution enhances the accessibility and usability of the repository by providing clear and concise setup instructions for deploying a Dockerized PostgreSQL database.